### PR TITLE
Split build for Bluetooth functionality to compile on non-Linux systems

### DIFF
--- a/bluetooth/conn.go
+++ b/bluetooth/conn.go
@@ -1,12 +1,8 @@
 package bluetooth
 
 import (
-	"errors"
-	"log"
 	"net"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 // Connection is a minimal wrapper around a UNIX Bluetooth socket; it conforms to the net.Conn interface for use by higher level libraries.
@@ -15,49 +11,6 @@ type Connection struct {
 
 	local  *Address
 	remote *Address
-}
-
-// Connect establishes an RFCOMM socket to the specified Bluetooth address using the specified channel.
-func (btc *Connection) Connect(remote *Address, channel uint8) error {
-	if btc.fd > 0 {
-		return errors.New("already connected")
-	} else if remote == nil {
-		return errors.New("address required")
-	}
-
-	fd, err := unix.Socket(unix.AF_BLUETOOTH, unix.SOCK_STREAM, unix.BTPROTO_RFCOMM)
-	if err != nil {
-		log.Printf("unable to create socket: %s\n", err.Error())
-		return err
-	}
-
-	if err := unix.Connect(fd, &unix.SockaddrRFCOMM{Addr: remote.bytes, Channel: channel}); err != nil {
-		log.Printf("unable to connect: %s\n", err.Error())
-		return err
-	}
-
-	btc.fd = fd
-	btc.remote = remote
-	return nil
-}
-
-// Read reads data from the connection.
-func (btc *Connection) Read(b []byte) (n int, err error) {
-	return unix.Read(btc.fd, b)
-}
-
-// Write writes data to the connection.
-func (btc *Connection) Write(b []byte) (n int, err error) {
-	return unix.Write(btc.fd, b)
-}
-
-// Close closes the connection.
-func (btc *Connection) Close() error {
-	if err := unix.Close(btc.fd); err != nil {
-		return err
-	}
-	btc.fd = 0
-	return nil
 }
 
 // LocalAddr returns the local address of the connection.

--- a/bluetooth/conn_linux.go
+++ b/bluetooth/conn_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package bluetooth
+
+import (
+	"errors"
+	"log"
+
+	"golang.org/x/sys/unix"
+)
+
+// Connect establishes an RFCOMM socket to the specified Bluetooth address using the specified channel.
+func (btc *Connection) Connect(remote *Address, channel uint8) error {
+	if btc.fd > 0 {
+		return errors.New("already connected")
+	} else if remote == nil {
+		return errors.New("address required")
+	}
+
+	fd, err := unix.Socket(unix.AF_BLUETOOTH, unix.SOCK_STREAM, unix.BTPROTO_RFCOMM)
+	if err != nil {
+		log.Printf("unable to create socket: %s\n", err.Error())
+		return err
+	}
+
+	if err := unix.Connect(fd, &unix.SockaddrRFCOMM{Addr: remote.bytes, Channel: channel}); err != nil {
+		log.Printf("unable to connect: %s\n", err.Error())
+		return err
+	}
+
+	btc.fd = fd
+	btc.remote = remote
+	return nil
+}
+
+// Read reads data from the connection.
+func (btc *Connection) Read(b []byte) (n int, err error) {
+	return unix.Read(btc.fd, b)
+}
+
+// Write writes data to the connection.
+func (btc *Connection) Write(b []byte) (n int, err error) {
+	return unix.Write(btc.fd, b)
+}
+
+// Close closes the connection.
+func (btc *Connection) Close() error {
+	if err := unix.Close(btc.fd); err != nil {
+		return err
+	}
+	btc.fd = 0
+	return nil
+}

--- a/bluetooth/conn_other.go
+++ b/bluetooth/conn_other.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+package bluetooth
+
+import "errors"
+
+// Connect returns that this isn't supported on this platform
+func (btc *Connection) Connect(remote *Address, channel uint8) error {
+	return errors.New("not supported")
+}
+
+// Read reads data from the connection.
+func (btc *Connection) Read(b []byte) (n int, err error) {
+	return -1, errors.New("not supported")
+}
+
+// Write writes data to the connection.
+func (btc *Connection) Write(b []byte) (n int, err error) {
+	return -1, errors.New("not supported")
+}
+
+// Close closes the connection.
+func (btc *Connection) Close() error {
+	return nil
+}


### PR DESCRIPTION
- Mac OS doesn't support AF_BLUETOOTH, so split by Linux/non-Linux and not Unix/non-Unix